### PR TITLE
compatibility work for 1.9.2 - case statement & initialization value

### DIFF
--- a/lib/whoops_logger/configuration.rb
+++ b/lib/whoops_logger/configuration.rb
@@ -80,9 +80,12 @@ module WhoopsLogger
 
     def set(config)
       case config
-      when Hash: set_with_hash(config)
-      when IO: set_with_io(config)
-      when String: set_with_string(config)
+      when Hash 
+        set_with_hash(config)
+      when IO
+        set_with_io(config)
+      when String
+        set_with_string(config)
       end
     end
     

--- a/lib/whoops_logger/message_creator.rb
+++ b/lib/whoops_logger/message_creator.rb
@@ -11,7 +11,7 @@ module WhoopsLogger
       self.strategy = strategy
       self.raw_data = raw_data
       self.message = Message.new
-      self.message.time = Time.now
+      self.message.event_time = Time.now
       self.message.logger_strategy_name = strategy.respond_to?(:name) ? strategy.name : 'anonymous'
     end
     


### PR DESCRIPTION
I probably should have make this 2 different fixes but bear with me, I'm new to github :)
- case statement compatibility with 1.9.2
- initialization of event time
# 

Still unable to make it work on 1.9.2 

undefined method `logger' for #WhoopsLogger::Configuration:0x996432c

/home/thierry/.rvm/gems/ruby-1.9.2-p180@test/bundler/gems/whoops_logger-8365db69583f/lib/whoops_logger/sender.rb:80:in `logger'
/home/thierry/.rvm/gems/ruby-1.9.2-p180@test/bundler/gems/whoops_logger-8365db69583f/lib/whoops_logger/sender.rb:32:in`send_message'
/home/thierry/.rvm/gems/ruby-1.9.2-p180@test/bundler/gems/whoops_logger-8365db69583f/lib/whoops_logger.rb:32:in `send_message'
/home/thierry/.rvm/gems/ruby-1.9.2-p180@test/bundler/gems/whoops_logger-8365db69583f/lib/whoops_logger.rb:27:in`log'
